### PR TITLE
기본 프로젝트 공통 설정 및 전역 응답 템플릿 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/carefreepass/com/carefreepassserver/CareFreePassServerApplication.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/CareFreePassServerApplication.java
@@ -2,8 +2,10 @@ package org.carefreepass.com.carefreepassserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class CareFreePassServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/config/JpaAuditingConfig.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package org.carefreepass.com.carefreepassserver.golbal.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/config/RedisConfig.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package org.carefreepass.com.carefreepassserver.golbal.config;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.carefreepass.com.carefreepassserver.golbal.properties.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config =
+                new RedisStandaloneConfiguration(redisProperties.host(), redisProperties.port());
+        config.setPassword(redisProperties.password());
+
+        LettuceClientConfiguration clientConfig =
+                LettuceClientConfiguration.builder()
+                        .commandTimeout(Duration.ofSeconds(1))
+                        .shutdownTimeout(Duration.ZERO)
+                        .build();
+
+        return new LettuceConnectionFactory(config, clientConfig);
+    }
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/config/SecurityConfig.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package org.carefreepass.com.carefreepassserver.golbal.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 모든 요청 임시 허용
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/config/SwaggerConfig.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/config/SwaggerConfig.java
@@ -1,0 +1,61 @@
+package org.carefreepass.com.carefreepassserver.golbal.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.carefreepass.com.carefreepassserver.golbal.properties.SwaggerProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    private static final String SWAGGER_TITLE = "CareFreePass API";
+    private static final String SWAGGER_DESCRIPTION = "CareFreePass API Documentation";
+
+    private static final String BEARER_SCHEME_NAME = "BearerAuth";
+    private static final String BEARER_TYPE = "bearer";
+    private static final String BEARER_FORMAT = "JWT";
+
+    private static final String LOCAL_IDENTIFIER = "localhost";
+    private static final String LOCAL_SERVER = "Local Server";
+    private static final String DEV_SERVER = "Dev Server";
+
+    private final SwaggerProperties swaggerProperties;
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(apiInfo())
+                .servers(List.of(server()))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_SCHEME_NAME))
+                .components(new Components().addSecuritySchemes(
+                                BEARER_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .name(BEARER_SCHEME_NAME)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme(BEARER_TYPE)
+                                        .bearerFormat(BEARER_FORMAT)
+                        )
+                );
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title(SWAGGER_TITLE)
+                .description(SWAGGER_DESCRIPTION)
+                .version(swaggerProperties.version());
+    }
+
+    private Server server() {
+        String url = swaggerProperties.url();
+        String description = url.contains(LOCAL_IDENTIFIER) ? LOCAL_SERVER : DEV_SERVER;
+        return new Server().url(url).description(description);
+    }
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/domain/BaseTimeEntity.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package org.carefreepass.com.carefreepassserver.golbal.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/domain/Status.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/domain/Status.java
@@ -1,0 +1,10 @@
+package org.carefreepass.com.carefreepassserver.golbal.domain;
+
+public enum Status {
+    ACTIVE("활성화"),
+    INACTIVE("비활성화"),
+    DELETED("삭제");
+
+    Status(String description) {
+    }
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/error/BusinessException.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/error/BusinessException.java
@@ -1,0 +1,22 @@
+package org.carefreepass.com.carefreepassserver.golbal.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(
+            final ErrorCode errorCode,
+            final String detailMessage
+    ) {
+        super("%s - %s".formatted(errorCode.getMessage(), detailMessage));
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/error/ErrorCode.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/error/ErrorCode.java
@@ -1,0 +1,29 @@
+package org.carefreepass.com.carefreepassserver.golbal.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 인증/인가
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_4010", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_4030", "접근 권한이 없습니다."),
+
+    // 회원 관련
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4041", "회원을 찾을 수 없습니다."),
+
+    // 잘못된 요청
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "REQ_4000", "잘못된 요청입니다."),
+
+    // 서버 오류
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SRV_5000", "서버 내부 오류가 발생했습니다."),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "SRV_5030", "현재 서비스를 사용할 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/error/ErrorResponse.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/error/ErrorResponse.java
@@ -1,0 +1,10 @@
+package org.carefreepass.com.carefreepassserver.golbal.error;
+
+public record ErrorResponse(
+        String code,
+        String message
+) {
+    public static ErrorResponse of(final String code, final String message) {
+        return new ErrorResponse(code, message);
+    }
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/error/GlobalExceptionHandler.java
@@ -1,0 +1,102 @@
+package org.carefreepass.com.carefreepassserver.golbal.error;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.carefreepass.com.carefreepassserver.golbal.log.BusinessExceptionLogEntry;
+import org.carefreepass.com.carefreepassserver.golbal.log.ExceptionLogEntry;
+import org.carefreepass.com.carefreepassserver.golbal.response.ApiResponseTemplate;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    private static final String BUSINESS_LOG_MARKER = "BUSINESS-EXCEPTION-LOG";
+    private static final String SYSTEM_LOG_MARKER = "EXCEPTION-LOG";
+
+    @ExceptionHandler(BusinessException.class)
+    public ApiResponseTemplate<Void> handleBusinessException(
+            final BusinessException ex,
+            final HttpServletRequest request
+    ) {
+        doBusinessLog(ex, request);
+
+        final ErrorCode errorCode = ex.getErrorCode();
+        final String detail = nullSafe(ex.getMessage(), errorCode.getMessage());
+
+        return ApiResponseTemplate.error()
+                .code(errorCode.getCode())
+                .message(detail)
+                .body(null);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ApiResponseTemplate<Void> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
+        FieldError fieldError = Objects.requireNonNull(e.getFieldError());
+
+        log.error("Validation error for field {}: {}", fieldError.getField(), fieldError.getDefaultMessage());
+        return ApiResponseTemplate.error()
+                .code(ErrorCode.BAD_REQUEST.getCode())
+                .message(String.format("%s. (%s)", fieldError.getDefaultMessage(), fieldError.getField()))
+                .body(null);
+
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ApiResponseTemplate<Void> handleException(
+            final Exception ex,
+            final HttpServletRequest request
+    ) {
+        doSystemLog(ex, request);
+
+        return ApiResponseTemplate.error()
+                .code(ErrorCode.INTERNAL_SERVER_ERROR.getCode())
+                .message(ErrorCode.INTERNAL_SERVER_ERROR.getMessage())
+                .body(null);
+    }
+
+    private void doBusinessLog(final RuntimeException runtimeException, final HttpServletRequest request) {
+        final BusinessExceptionLogEntry entry = BusinessExceptionLogEntry.builder()
+                .timestamp(OffsetDateTime.now().toString())
+                .exceptionType(runtimeException.getClass().getName())
+                .message(runtimeException.getMessage())
+                .requestUri(request.getRequestURI())
+                .build();
+        final Marker marker = MarkerFactory.getMarker(BUSINESS_LOG_MARKER);
+        log.warn(marker, entry.toLogString());
+    }
+
+    private void doSystemLog(final Exception exception, final HttpServletRequest request) {
+        final ExceptionLogEntry entry = ExceptionLogEntry.builder()
+                .timestamp(OffsetDateTime.now().toString())
+                .exceptionType(exception.getClass().getName())
+                .message(exception.getMessage())
+                .requestUri(request.getRequestURI())
+                .stackTrace(toStackTraceLog(exception))
+                .build();
+        final Marker marker = MarkerFactory.getMarker(SYSTEM_LOG_MARKER);
+        log.error(marker, entry.toLogString());
+    }
+
+    private static String nullSafe(final String primary, final String fallback) {
+        return (primary == null || primary.isBlank()) ? fallback : primary;
+    }
+
+    private String toStackTraceLog(final Exception exception) {
+        return Arrays.stream(exception.getStackTrace())
+                .map(StackTraceElement::toString)
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/log/BusinessExceptionLogEntry.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/log/BusinessExceptionLogEntry.java
@@ -1,0 +1,35 @@
+package org.carefreepass.com.carefreepassserver.golbal.log;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BusinessExceptionLogEntry {
+
+    private String timestamp;
+    private String exceptionType;
+    private String message;
+    private String requestUri;
+    private String stackTrace;
+
+    public String toLogString() {
+        return String.format("""
+            
+            [BUSINESS-EXCEPTION]
+              Time          : %s
+              ExceptionType : %s
+              Message       : %s
+              Request URI   : %s
+            -------------------- Stack Trace -------------------
+            %s
+            ----------------------------------------------------
+            """,
+                timestamp,
+                exceptionType,
+                message,
+                requestUri,
+                stackTrace
+        );
+    }
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/log/ExceptionLogEntry.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/log/ExceptionLogEntry.java
@@ -1,0 +1,35 @@
+package org.carefreepass.com.carefreepassserver.golbal.log;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ExceptionLogEntry {
+
+    private String timestamp;
+    private String exceptionType;
+    private String message;
+    private String requestUri;
+    private String stackTrace;
+
+    public String toLogString() {
+        return String.format("""
+                
+                [EXCEPTION]
+                  Time          : %s
+                  ExceptionType : %s
+                  Message       : %s
+                  Request URI   : %s
+                ----------------- Stack Trace -----------------
+                %s
+                ------------------------------------------------
+                """,
+                timestamp,
+                exceptionType,
+                message,
+                requestUri,
+                stackTrace
+        );
+    }
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/properties/RedisProperties.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/properties/RedisProperties.java
@@ -1,0 +1,11 @@
+package org.carefreepass.com.carefreepassserver.golbal.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+public record RedisProperties(
+        String host,
+        int port,
+        String password
+) {
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/properties/SwaggerProperties.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/properties/SwaggerProperties.java
@@ -1,0 +1,10 @@
+package org.carefreepass.com.carefreepassserver.golbal.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "swagger")
+public record SwaggerProperties(
+        String version,
+        String url
+) {
+}

--- a/src/main/java/org/carefreepass/com/carefreepassserver/golbal/response/ApiResponseTemplate.java
+++ b/src/main/java/org/carefreepass/com/carefreepassserver/golbal/response/ApiResponseTemplate.java
@@ -1,0 +1,59 @@
+package org.carefreepass.com.carefreepassserver.golbal.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponseTemplate<T> {
+
+    private final String code;
+    private final String message;
+    private final T data;
+
+    public static BodyBuilder ok() {
+        return new DefaultBodyBuilder();
+    }
+
+    public static BodyBuilder error() {
+        return new DefaultBodyBuilder();
+    }
+
+    public interface BodyBuilder {
+        BodyBuilder code(final String code);
+
+        BodyBuilder message(final String message);
+
+        <T> ApiResponseTemplate<T> body(final T data);
+
+        <T> ApiResponseTemplate<T> build();
+    }
+
+    private static final class DefaultBodyBuilder implements BodyBuilder {
+        private String code;
+        private String message;
+
+        @Override
+        public BodyBuilder code(final String code) {
+            this.code = code;
+            return this;
+        }
+
+        @Override
+        public BodyBuilder message(final String message) {
+            this.message = message;
+            return this;
+        }
+
+        @Override
+        public <T> ApiResponseTemplate<T> body(final T data) {
+            return new ApiResponseTemplate<>(this.code, this.message, data);
+        }
+
+        @Override
+        public <T> ApiResponseTemplate<T> build() {
+            return new ApiResponseTemplate<>(this.code, this.message, null);
+        }
+    }
+}

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: "datasource"
+  datasource:
+    url: jdbc:mariadb://${MARIADB_HOST:localhost}:${MARIADB_PORT:3307}/${DB_NAME}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    driver-class-name: org.mariadb.jdbc.Driver
+    username: ${MARIADB_USERNAME}
+    password: ${MARIADB_PASSWORD}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,18 @@
+spring:
+  config:
+    activate:
+      on-profile: "dev"
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    open-in-view: false
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,18 @@
+spring:
+  config:
+    activate:
+      on-profile: "local"
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: false
+        format_sql: true
+    open-in-view: false
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: "redis"
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=CareFreePass-Server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  application:
+    name: CareFreePass-Server
+  profiles:
+    group:
+      local: "local, datasource"
+      dev: "dev, datasource"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,7 @@ spring:
     group:
       local: "local, datasource"
       dev: "dev, datasource"
+
+swagger:
+  version: ${SWAGGER_VERSION:0.0.1}
+  url: ${SWAGGER_URL:http://localhost:8080}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,9 @@ spring:
       local: "local, datasource"
       dev: "dev, datasource"
 
+    include:
+      - redis
+
 swagger:
   version: ${SWAGGER_VERSION:0.0.1}
   url: ${SWAGGER_URL:http://localhost:8080}


### PR DESCRIPTION
### 🌳 이슈 번호

close #1

---

### ☀️ 어떻게 이슈를 해결했나요?

* Spring Security 기본 설정(SecurityConfig) 추가
  * HttpBasic, FormLogin, CSRF 비활성화
  * 세션 Stateless 설정
  * PasswordEncoder Bean 등록
* JPA 공통 엔티티 `BaseTimeEntity` 추가 (생성일/수정일 자동 관리)
* 전역 상태값 `Status` Enum 정의
* `application.yml` 프로필(local/dev) 분리 및 datasource 설정
* API 공통 응답 템플릿 `ApiResponseTemplate` 추가 
* Swagger 기초 설정
* Redis 기초 설정

---

### ❄️ 주의할 점

* 현재 Security는 모든 요청을 `permitAll` 로 임시 개방 상태 → 추후 인증 로직 연결 필요
* `application.yml` 은 로컬/개발 DB 환경에 맞춰 작성, 배포 시 prod 프로필 별도 분리 필요

---
